### PR TITLE
[FIX][IMP] Update Process and Actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if not os.getenv("DISABLE_PYTEST_ODOO"):
 
 setup(
     name="doblib",
-    version="0.13.0",
+    version="0.14.0",
     author="initOS GmbH",
     author_email="info@initos.com",
     description="Management tool for Odoo installations",

--- a/src/doblib/action.py
+++ b/src/doblib/action.py
@@ -20,6 +20,14 @@ def load_action_arguments(args, actions=None):
         help=f"Action to run. Possible choices: {','.join(actions)}",
     )
     parser.add_argument(
+        "steps",
+        default=[],
+        action="extend",
+        type=str,
+        nargs="*",
+        help="Specific steps to run",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         default=False,
@@ -356,6 +364,9 @@ class ActionEnvironment(env.Environment):
             with self.env(db_name) as env:
                 for name, item in actions[args.action].items():
                     if not item.get("enable", True):
+                        continue
+
+                    if args.steps and name not in args.steps:
                         continue
 
                     utils.info(f"{args.action.capitalize()} {name}")

--- a/src/doblib/action.py
+++ b/src/doblib/action.py
@@ -22,7 +22,7 @@ def load_action_arguments(args, actions=None):
     parser.add_argument(
         "steps",
         default=[],
-        action="extend",
+        action="append",
         type=str,
         nargs="*",
         help="Specific steps to run",

--- a/src/doblib/action.py
+++ b/src/doblib/action.py
@@ -366,7 +366,9 @@ class ActionEnvironment(env.Environment):
                     if not item.get("enable", True):
                         continue
 
-                    if args.steps and name not in args.steps:
+                    steps = sum(args.steps, [])
+
+                    if steps and name not in steps:
                         continue
 
                     utils.info(f"{args.action.capitalize()} {name}")

--- a/src/doblib/module.py
+++ b/src/doblib/module.py
@@ -116,7 +116,9 @@ class ModuleEnvironment(env.Environment):
             force_demo=not without_demo,
         )
 
-    def update_specific(self, db_name, whitelist=None, blacklist=None, installed=False):
+    def update_specific(
+        self, db_name, whitelist=None, blacklist=None, installed=False, listed=False
+    ):
         """Update all modules"""
         # pylint: disable=C0415,E0401
         import odoo
@@ -126,13 +128,16 @@ class ModuleEnvironment(env.Environment):
 
         if installed:
             utils.info("Updating all modules")
-            modules = self._get_installed_modules(db_name)
-        else:
+            modules = ["all"]
+        elif listed:
             utils.info("Updating listed modules")
             modules = self._get_modules()
+        else:
+            utils.info("Updating specific modules")
+            modules = self._get_installed_modules(db_name)
 
-        modules = (modules or whitelist).intersection(whitelist)
-        modules.difference_update(blacklist or [])
+            modules = (modules or whitelist).intersection(whitelist)
+            modules.difference_update(blacklist or [])
 
         config["init"] = {}
         config["update"] = dict.fromkeys(modules, 1)
@@ -206,6 +211,7 @@ class ModuleEnvironment(env.Environment):
                     whitelist=args.modules,
                     blacklist=uninstalled,
                     installed=args.all,
+                    listed=args.listed,
                 )
             else:
                 self.update_changed(db_name, uninstalled)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -81,7 +81,6 @@ def test_install_all(env):
 def test_update_all(env):
     odoo = sys.modules["odoo"] = mock.MagicMock()
     sys.modules["odoo.tools"] = mock.MagicMock()
-    env._get_installed_modules = mock.MagicMock()
 
     env.update_specific("odoo", installed=True)
     odoo.modules.registry.Registry.new.assert_called_once_with(
@@ -89,15 +88,13 @@ def test_update_all(env):
         update_module=True,
     )
 
-    env._get_installed_modules.assert_called_once()
-
 
 def test_update_listed(env):
     odoo = sys.modules["odoo"] = mock.MagicMock()
     sys.modules["odoo.tools"] = mock.MagicMock()
     env._get_modules = mock.MagicMock()
 
-    env.update_specific("odoo")
+    env.update_specific("odoo", listed=True)
     odoo.modules.registry.Registry.new.assert_called_once_with(
         "odoo",
         update_module=True,
@@ -165,6 +162,7 @@ def test_update(env):
         whitelist=["abc", "def"],
         blacklist={"normal"},
         installed=False,
+        listed=False,
     )
 
 


### PR DESCRIPTION
The update process has some unexpected behaviour if not `update_changed` is used.

If `--all` is passed all installed modules should be updated. pre patch nothing happens
If `--listed` is passed only the modules listed in the configuration under `modules` should be updated (+ downstream dependencies)
If module names are passed only these modules should be updated. pre patch nothing happens (+ downstream dependencies)

Additional allow to specify specific steps of an action to be executed.